### PR TITLE
chore: reduce target platforms and add Terraform Registry metadata

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,11 +5,8 @@ builds:
     flags: ["-trimpath"]
     ldflags:
       - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
-    goos: [freebsd, windows, linux, darwin]
-    goarch: [amd64, '386', arm, arm64]
-    ignore:
-      - goos: darwin
-        goarch: '386'
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
     binary: terraform-provider-slack
 
 archives:

--- a/registry-docs.json
+++ b/registry-docs.json
@@ -1,0 +1,14 @@
+{
+  "name": "slack",
+  "type": "provider",
+  "owner": "gfnogueira",
+  "description": "A Terraform provider for managing Slack resources like channels, users, and user groups.",
+  "source": "github.com/gfnogueira/terraform-provider-slack",
+  "license": "GPL-3.0",
+  "tags": [
+    "slack",
+    "terraform",
+    "chatops",
+    "provider"
+  ]
+}


### PR DESCRIPTION
- Removed unsupported or low-demand builds: freebsd and all 386 architectures
- Kept only amd64 and arm64 for linux, darwin (macOS), and windows
- Added `registry-docs.json` to support publishing on the Terraform Registry

## Description

Please include a summary of the change and which issue is fixed.

Fixes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
